### PR TITLE
Extend object IDs

### DIFF
--- a/src/id.ts
+++ b/src/id.ts
@@ -1,7 +1,21 @@
 import { ByteArray, crypto, ethereum } from "@graphprotocol/graph-ts";
 
 export function shortUniqueId(longId: string): string {
-    return shortId(crypto.keccak256(ByteArray.fromUTF8(longId)).toHexString())
+    return shortId(uniqueId(longId))
+}
+
+export function uniqueId(longId: string): string {
+    // array is 32 bytes long, need to shorten to 20
+    // need to keep the first 2 and last 2 bytes the same
+    // so that the shortened ID remains identical
+    let array = crypto.keccak256(ByteArray.fromUTF8(longId))
+    for (let i = 18; i < 30; i++) {
+        // overlap bytes 18 to 30 onto bytes 2 to 14 via XOR
+        array[i - 16] ^= array[i]
+    }
+    let arrayString = array.toHexString()
+    // skip out the 12 bytes that were overlapped above
+    return arrayString.slice(0, 38) + arrayString.slice(62, 66)
 }
 
 export function shortId(longId: string): string {

--- a/src/internal/board.ts
+++ b/src/internal/board.ts
@@ -1,11 +1,11 @@
 import { Message } from "../../generated/Relay/Relay";
 import { Board, BoardCreationEvent, Post, Thread } from "../../generated/schema";
-import { eventId, shortUniqueId } from "../id";
+import { eventId, uniqueId } from "../id";
 
 export type BoardId = string
 
 export function boardId(message: Message) : BoardId {
-    return shortUniqueId(eventId(message))
+    return uniqueId(eventId(message))
 }
 
 export function loadBoardFromId(id: BoardId) : Board | null {

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -1,8 +1,8 @@
 import { Message } from "../../generated/Relay/Relay";
-import { eventId, shortUniqueId } from "../id";
+import { eventId, uniqueId } from "../id";
 
 export type ClientId = string
 
 export function clientIdFromMessage(message: Message): ClientId {
-    return shortUniqueId(eventId(message))
+    return uniqueId(eventId(message))
 }

--- a/src/internal/post.ts
+++ b/src/internal/post.ts
@@ -1,11 +1,11 @@
 import { Message } from "../../generated/Relay/Relay";
 import { Post, PostCreationEvent } from "../../generated/schema";
-import { eventId, shortUniqueId } from "../id";
+import { eventId, uniqueId } from "../id";
 
 export type PostId = string
 
 export function postId(message: Message): PostId {
-    return shortUniqueId(eventId(message))
+    return uniqueId(eventId(message))
 }
 
 export function loadPostFromId(id: PostId) : Post | null {

--- a/src/internal/thread.ts
+++ b/src/internal/thread.ts
@@ -1,11 +1,11 @@
 import { Message } from "../../generated/Relay/Relay";
 import { Thread, ThreadCreationEvent } from "../../generated/schema";
-import { eventId, shortUniqueId } from "../id";
+import { eventId, uniqueId } from "../id";
 
 export type ThreadId = string
 
 export function threadId(message: Message): ThreadId {
-    return shortUniqueId(eventId(message))
+    return uniqueId(eventId(message))
 }
 
 export function loadThreadFromId(id: ThreadId) : Thread | null {

--- a/src/operations/post_create.ts
+++ b/src/operations/post_create.ts
@@ -2,7 +2,7 @@ import { BigInt, JSONValue, log, TypedMap } from "@graphprotocol/graph-ts";
 import { Message } from "../../generated/Relay/Relay";
 import { Board, Image, Post, Thread, User } from "../../generated/schema";
 import { ensureBoolean, ensureNumber, ensureObject, ensureString } from "../ensure";
-import { eventId, shortUniqueId } from "../id";
+import { eventId, uniqueId } from "../id";
 import { POST_COMMENT_MAX_LENGTH, POST_FILENAME_MAX_LENGTH, POST_NAME_MAX_LENGTH, POST_SUBJECT_MAX_LENGTH } from "../constants";
 import { scoreDefault } from "../score";
 import { createPostCreationEvent, createThreadCreationEvent } from "../internal/creation_event";
@@ -106,7 +106,7 @@ export function postCreate(message: Message, user: User, data: TypedMap<string, 
             let isNsfw = "true" == ensureBoolean(file.get('is_nsfw'))
             let isSpoiler = "true" == ensureBoolean(file.get('is_spoiler'))
 
-            image = new Image(shortUniqueId(evtId))
+            image = new Image(uniqueId(evtId))
             image.score = scoreDefault()
             image.name = name
             image.byteSize = byteSize as BigInt


### PR DESCRIPTION
Replaced each of the shortened IDs given to objects with an ID the same length as a wallet address (20 bytes). The new IDs shorten identically to the old IDs, so the only thing this should affect is URLs.

Keeping the old IDs (which only have 3 bytes of data) would mean that there could only be up to 16777216 objects of a given type before collisions start occurring. Moving users to longer IDs helps already (especially since you can just mine for identical shortened IDs), but by definition there will be more boards/threads/posts on the site than there are users, and eventually this switch would need to be made anyway. Doing this now will give the site much more capacity to grow in future, and hopefully this will mean IDs can remain stable.

One consideration this PR doesn't account for is existing URLs, which would become invalidated as a result of this change. If that does matter, maybe we can add a mapping of shortened IDs to full ones, where new IDs generated that would cause a collision aren't added to the mapping. Personally though, I don't think this is anything to worry about, since I doubt anyone is going to rely on permalinks for a site in alpha with not even 1000 posts, and if anything I'd rather force everyone onto the new IDs just for the sake of consistency and minimising future headache.